### PR TITLE
Added INTERNET permission to example app Manifest

### DIFF
--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
 	<uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 	<uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
+	<uses-permission android:name="android.permission.INTERNET"/>
 
 	<application android:allowBackup="true"
 				 android:label="@string/app_name"


### PR DESCRIPTION
In the library README, it is already mentioned that `INTERNET` permission (in addition to `ACCESS_WIFI_STATE` and `CHANGE_WIFI_MULTICAST_STATE`) are required if using the support implementation. However, the example app, which uses the support implementation, is missing the `INTERNET` permission.
