### PR TITLE
Optional Dot for Service Types

### DIFF
--- a/rxbonjour/src/main/java/rxbonjour/RxBonjour.java
+++ b/rxbonjour/src/main/java/rxbonjour/RxBonjour.java
@@ -18,7 +18,7 @@ import static android.os.Build.VERSION_CODES.JELLY_BEAN;
  */
 public final class RxBonjour {
 
-	private static final String TYPE_PATTERN = "_[a-zA-Z0-9\\-]+.(_tcp|_udp)";
+	private static final String TYPE_PATTERN = "_[a-zA-Z0-9\\-]+.(_tcp|_udp)?\\.";
 
 	private RxBonjour() {
 		throw new AssertionError("no instances");

--- a/rxbonjour/src/main/java/rxbonjour/RxBonjour.java
+++ b/rxbonjour/src/main/java/rxbonjour/RxBonjour.java
@@ -18,7 +18,7 @@ import static android.os.Build.VERSION_CODES.JELLY_BEAN;
  */
 public final class RxBonjour {
 
-	private static final String TYPE_PATTERN = "_[a-zA-Z0-9\\-]+.(_tcp|_udp)?\\.";
+	private static final String TYPE_PATTERN = "_[a-zA-Z0-9\\-]+.(_tcp|_udp)(\\.|\\b)";
 
 	private RxBonjour() {
 		throw new AssertionError("no instances");


### PR DESCRIPTION
First of all thanks for the library! Service Type names have in my company an additional dot at the end. For instance: '_http._tcp.local.' which the regex would deny. I would appreciate if we can adapt it in main repository.
